### PR TITLE
Fixed issue where unbuffered js blocks don't get highlighted

### DIFF
--- a/grammars/pug.cson
+++ b/grammars/pug.cson
@@ -16,15 +16,7 @@ patterns: [
     name: "comment.other.doctype.jade"
   }
   {
-    begin: "^(\\s*)-$"
-    comment: "Unbuffered code block."
-    end: "^(?!(\\1\\s)|\\s*$)"
-    name: "source.js"
-    patterns: [
-      {
-        include: "source.js"
-      }
-    ]
+    include: "#unbuffered_code_block"
   }
   {
     begin: "^(\\s*)(script)(?=[.#(\\s])((?![^\\n]*type=)|(?=[^\\n]*type=['\"](text|application)/javascript['\"]))"
@@ -475,6 +467,9 @@ patterns: [
       }
       {
         include: "#unbuffered_code"
+      }
+      {
+        include: "#unbuffered_code_block"
       }
       {
         include: "#mixin_definition"
@@ -1142,6 +1137,16 @@ repository:
       {
         include: "#js_brackets"
       }
+      {
+        include: "source.js"
+      }
+    ]
+  unbuffered_code_block:
+    begin: "^(\\s*)-(\r|\n)"
+    comment: "Unbuffered code block."
+    end: "^(?!(\\1\\s)|\\s*$)"
+    name: "source.js"
+    patterns: [
       {
         include: "source.js"
       }

--- a/grammars/pug.cson
+++ b/grammars/pug.cson
@@ -460,6 +460,9 @@ patterns: [
         include: "#buffered_comments"
       }
       {
+        include: "#unbuffered_code_block"
+      }
+      {
         include: "#inline_pug"
       }
       {
@@ -467,9 +470,6 @@ patterns: [
       }
       {
         include: "#unbuffered_code"
-      }
-      {
-        include: "#unbuffered_code_block"
       }
       {
         include: "#mixin_definition"


### PR DESCRIPTION
This pull request fixes an issue where compile-time js blocks wouldn't get scoped for js.

### Before
![image](https://cloud.githubusercontent.com/assets/4605023/20463802/52674420-af09-11e6-952f-061d12656745.png)

### After
![image](https://cloud.githubusercontent.com/assets/4605023/20464000/f4a5d0e6-af0c-11e6-8202-3c25db667234.png)


