### PR TITLE
Fix tag_name scope

### DIFF
--- a/grammars/pug.cson
+++ b/grammars/pug.cson
@@ -1088,12 +1088,12 @@ repository:
   tag_name:
     begin: "([#!]\\{(?=.*?\\}))|(\\w(([\\w:-]+[\\w-])|([\\w-]*)))"
     end: "(\\G(?<!\\5[^\\w-]))|\\}|$"
-    name: "source.script.jade entity.name.tag.pug"
+    name: "entity.name.tag.pug"
     patterns: [
       {
         begin: "\\G(?<=\\{)"
         end: "(?=\\})"
-        name: "source.script.jade entity.name.tag.pug"
+        name: "entity.name.tag.pug"
         patterns: [
           {
             match: "{"


### PR DESCRIPTION
I'm not sure if both scope names are needed (maybe for js blocks?) but having them seperated with a space was causing incorrect syntax highlighting.

Before change:
<img width="169" alt="2018-01-27_20 40 00-a4f19110" src="https://user-images.githubusercontent.com/3316789/35476125-db50ee96-03a2-11e8-9167-a4ead639c6b9.png">
 
After change:
<img width="147" alt="2018-01-27_20 41 12-1251dff6" src="https://user-images.githubusercontent.com/3316789/35476134-02f7b286-03a3-11e8-8513-14d4da2c14b0.png">
